### PR TITLE
Fix site.js syntax error that blocked CV rendering on GitHub Pages.

### DIFF
--- a/js/site.js
+++ b/js/site.js
@@ -362,7 +362,7 @@
       "</a> · " +
       '<a href="' +
       escapeHtml(p.contact.linkedin) +
-      '" rel="noopener noreferrer">LinkedIn</a></p></header>" +
+      '" rel="noopener noreferrer">LinkedIn</a></p></header>' +
       '<hr class="rule" />' +
       '<section aria-labelledby="summary-heading"><h2 id="summary-heading">' +
       escapeHtml(t("sections.summary")) +


### PR DESCRIPTION
A mismatched quote on the LinkedIn header string caused a parse error at load time, leaving the page stuck on Loading.

## Scope
- What changed?
- Why?

## Validation (static site)
- [ ] Served locally (`npx serve .`) — CV and work page load
- [ ] Profile switcher works (`developer`, `sdr`)
- [ ] Language switcher works (`en`, `pt-BR`, `es`)
- [ ] `data/projects.json` valid JSON; demo URLs correct
- [ ] Print / Save as PDF acceptable on developer + en
- [ ] No secrets added or exposed
- [ ] No auth / billing / DNS / GitHub Pages settings change unless intended

## Risk
- Risk level: low / medium / high
- Rollback path: revert merge on `main` (GitHub Pages republishes from previous commit)
