### PR TITLE
Add Vercel edge invite gate for private résumé sharing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Copy to .env locally — never commit .env
+
+# Enable gate on Vercel (leave unset/false for local `npx serve` and public GitHub Pages)
+ACCESS_GATE_ENABLED=true
+
+# Generate: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+ACCESS_TOKEN_SECRET=
+
+# Session lifetime after successful unlock (hours)
+SESSION_HOURS=24
+
+# Used by scripts/issue-invite.mjs
+SITE_BASE_URL=https://your-app.vercel.app

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,8 +8,14 @@
 - [ ] Language switcher works (`en`, `pt-BR`, `es`)
 - [ ] `data/projects.json` valid JSON; demo URLs correct
 - [ ] Print / Save as PDF acceptable on developer + en
-- [ ] No secrets added or exposed
-- [ ] No auth / billing / DNS / GitHub Pages settings change unless intended
+- [ ] No secrets added or exposed (no `.env`, no `ACCESS_TOKEN_SECRET` in repo)
+- [ ] No auth / billing / DNS / hosting settings change unless intended
+
+## Validation (access gate — if this PR touches gate)
+- [ ] `vercel dev` — unauthenticated `/` redirects to `/unlock.html`
+- [ ] Valid invite link unlocks and sets session; `/data/*` blocked without cookie
+- [ ] Expired / tampered token rejected
+- [ ] GitHub Pages disabled or documented if full site must stay private
 
 ## Risk
 - Risk level: low / medium / high

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .DS_Store
 Thumbs.db
 desktop.ini
+.env
+.env.local
+.env.*.local
+.vercel

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# Facundo Leis Pou — CV & Portfolio (GitHub Pages)
+# Facundo Leis Pou — CV & Portfolio
 
 Merged static résumé + project showcase for dev job applications (primary) and SDR/sales opportunities (secondary).
 
 - **Repository:** [github.com/ezeleis/curriculo](https://github.com/ezeleis/curriculo)
-- **Published site:** [ezeleis.github.io/curriculo/](https://ezeleis.github.io/curriculo/)
+- **Gated deploy (recommended):** Vercel + invite-only access — see [docs/access-gate.md](docs/access-gate.md)
+- **Legacy public URL:** [ezeleis.github.io/curriculo/](https://ezeleis.github.io/curriculo/) — disable GitHub Pages when using the gate
 
 Supersedes the legacy `curriculo/` folder for new updates.
 
@@ -13,17 +14,14 @@ Supersedes the legacy `curriculo/` folder for new updates.
 facundo-leis-resume/
 ├── index.html              ← CV (profile + language driven)
 ├── work.html               ← project showcase
-├── data/
-│   ├── profiles/
-│   │   ├── developer.json  ← default: dev-focused CV
-│   │   └── sdr.json        ← sales/SDR-oriented CV
-│   ├── projects.json       ← work page source of truth
-│   └── i18n/
-│       ├── en.json         ← UI labels (default)
-│       ├── pt-BR.json
-│       └── es.json
+├── unlock.html             ← invite-only entry (Vercel gate)
+├── middleware.js           ← Edge gate (Vercel only)
+├── api/unlock.js           ← token exchange → session cookie
+├── lib/token.mjs           ← HMAC invite + session tokens
+├── data/                   ← CV + projects JSON
 ├── js/site.js              ← switchers + render (no build step)
-└── styles.css
+├── scripts/issue-invite.mjs← issue share links (run locally)
+└── docs/access-gate.md     ← security model + setup
 ```
 
 ## Profiles & languages
@@ -41,17 +39,33 @@ Preferences persist in `localStorage` and URL query params:
 
 ## Local preview
 
-Serve the folder over HTTP (required for JSON fetch):
+Serve the folder over HTTP (required for JSON fetch). Gate is **off** locally:
 
 ```bash
 npx --yes serve .
 ```
 
-Then open `http://localhost:3000` (or the port shown).
+To test the access gate, use [Vercel CLI](https://vercel.com/docs/cli): `npx vercel dev` with `.env` from `.env.example`.
 
-## GitHub Pages
+## Private access (invite links)
 
-Configured for **Deploy from a branch** → `main` → `/ (root)`. Push updates to refresh the live site within a few minutes.
+GitHub Pages cannot enforce real authentication (static files are public). For invite-only sharing:
+
+1. Deploy on **Vercel** with `ACCESS_GATE_ENABLED=true` and `ACCESS_TOKEN_SECRET` set — full guide in [docs/access-gate.md](docs/access-gate.md).
+2. **Disable GitHub Pages** for this repo (or keep only a minimal public stub) so JSON is not world-readable on `github.io`.
+3. Issue links locally:
+
+```powershell
+$env:ACCESS_TOKEN_SECRET = "same-secret-as-vercel"
+$env:SITE_BASE_URL = "https://your-app.vercel.app"
+node scripts/issue-invite.mjs --days 7 --label "Recruiter name"
+```
+
+Share the printed URL; recipient gets a 24h browser session (configurable).
+
+## GitHub Pages (optional / legacy)
+
+If enabled, publishes static files from `main` with **no gate**. Use only for a public teaser or disable when Vercel gate is active.
 
 ## PDF for applications
 
@@ -107,7 +121,7 @@ Each translatable field uses `{ "en": "...", "pt-BR": "...", "es": "..." }`.
 git checkout -b feat/showcase-<slug>
 # … edit, commit …
 git push -u origin HEAD
-# open PR → review → merge to main (publishes GitHub Pages)
+# open PR → review → merge to main (Vercel production deploy)
 ```
 
 Branch naming: `feat/showcase-<slug>`, `fix/showcase-<slug>`, `chore/showcase-<slug>`.

--- a/api/unlock.js
+++ b/api/unlock.js
@@ -1,0 +1,73 @@
+import {
+  gateEnabled,
+  verifyInviteToken,
+  createSessionToken,
+  SESSION_COOKIE
+} from "../lib/token.mjs";
+
+export const config = {
+  runtime: "edge"
+};
+
+function safeRedirectPath(value) {
+  if (!value || typeof value !== "string") return "/";
+  if (!value.startsWith("/") || value.startsWith("//")) return "/";
+  return value;
+}
+
+export default async function handler(request) {
+  if (request.method !== "POST") {
+    return new Response("Method not allowed", { status: 405 });
+  }
+
+  if (!gateEnabled(process.env)) {
+    return Response.json({ ok: true, redirect: "/" });
+  }
+
+  const secret = process.env.ACCESS_TOKEN_SECRET;
+  if (!secret) {
+    return Response.json({ ok: false, error: "misconfigured" }, { status: 503 });
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ ok: false, error: "invalid_body" }, { status: 400 });
+  }
+
+  const token = (body.token || "").trim();
+  if (!token) {
+    return Response.json({ ok: false, error: "missing_token" }, { status: 400 });
+  }
+
+  const invite = await verifyInviteToken(token, secret);
+  if (!invite.ok) {
+    return Response.json({ ok: false, error: invite.reason || "denied" }, { status: 401 });
+  }
+
+  const sessionHours = Number(process.env.SESSION_HOURS || 24);
+  const sessionToken = await createSessionToken(secret, invite.payload, sessionHours);
+  const redirect = safeRedirectPath(body.next);
+
+  const cookieParts = [
+    SESSION_COOKIE + "=" + encodeURIComponent(sessionToken),
+    "Path=/",
+    "HttpOnly",
+    "SameSite=Lax",
+    "Max-Age=" + String(sessionHours * 3600)
+  ];
+
+  if (new URL(request.url).protocol === "https:") {
+    cookieParts.push("Secure");
+  }
+
+  return new Response(JSON.stringify({ ok: true, redirect }), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+      "Set-Cookie": cookieParts.join("; ")
+    }
+  });
+}

--- a/docs/access-gate.md
+++ b/docs/access-gate.md
@@ -1,0 +1,103 @@
+# Access gate (SHOWCASE)
+
+Private invite-only access for the résumé site when deployed on **Vercel with Edge Middleware**.
+
+## Why not GitHub Pages alone?
+
+GitHub Pages serves **static files**. Anyone can fetch `/data/profiles/developer.json` directly. A password in client-side JavaScript is bypassable (view source, disable JS, curl).
+
+**Real gating requires server-side enforcement** before content is served. This implementation uses Vercel Edge Middleware + a signed-token unlock API.
+
+| Deployment | Gate works? |
+|---|---|
+| Vercel + env vars set | Yes |
+| Local `npx serve` (gate off) | No — dev mode |
+| GitHub Pages (`*.github.io`) | **No** — disable or publish only a public stub |
+
+## Threat model
+
+**Protects against**
+
+- Casual browsing / search engine indexing (with `noindex` on unlock page)
+- Direct URL access without a valid invite
+- Direct fetch of `/data/*` and `/js/*` without a session cookie
+- Expired or tampered invite links (HMAC-SHA256)
+
+**Does not protect against**
+
+- Someone you shared a valid link with forwarding it
+- Screen capture / copy-paste of content after unlock
+- Determined attacker with a leaked `ACCESS_TOKEN_SECRET` (rotate secret and redeploy)
+
+**Not “unbreakable”** — no web gate is. This is **appropriate for recruiter sharing**, not classified data.
+
+## Flow
+
+```text
+You (local CLI)                Visitor
+     |                              |
+     | issue-invite.mjs             |
+     |-- signed invite token ------> opens /unlock.html?invite=TOKEN
+     |                              POST /api/unlock
+     |                              <- Set-Cookie: fl_session (HttpOnly)
+     |                              -> CV + work pages
+Edge middleware on every request validates fl_session cookie
+```
+
+## Setup (Vercel)
+
+1. Import repo `ezeleis/curriculo` on Vercel (or link existing project).
+2. **Environment variables** (Production + Preview):
+
+   | Variable | Value |
+   |---|---|
+   | `ACCESS_GATE_ENABLED` | `true` |
+   | `ACCESS_TOKEN_SECRET` | 32+ char random secret (same for all envs) |
+   | `SESSION_HOURS` | `24` (optional) |
+
+3. Deploy from `main` after PR merge.
+4. **Disable GitHub Pages** or stop publishing full site there — otherwise content stays public on `github.io`.
+
+Generate secret (PowerShell):
+
+```powershell
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+```
+
+## Issue an invite link
+
+```powershell
+cd c:\Users\Admin\Projects\facundo-leis-resume
+$env:ACCESS_TOKEN_SECRET = "your-secret-from-vercel"
+$env:SITE_BASE_URL = "https://your-app.vercel.app"
+node scripts/issue-invite.mjs --days 7 --label "Google recruiter"
+```
+
+Share the printed URL only with the intended recipient.
+
+## Local development
+
+```powershell
+npx serve .
+```
+
+Gate is **off** unless you set `ACCESS_GATE_ENABLED=true` locally (Vercel CLI required to test middleware).
+
+Preview gate with Vercel CLI:
+
+```powershell
+npx vercel dev
+```
+
+## Rotate secret
+
+1. Set new `ACCESS_TOKEN_SECRET` on Vercel.
+2. Redeploy.
+3. All old invite links and sessions invalidate.
+4. Issue new invites.
+
+## Git workflow
+
+Work on `feat/showcase-access-gate` → PR → merge to `main` → Vercel production deploy.
+
+Do not push directly to `main`.

--- a/lib/token.mjs
+++ b/lib/token.mjs
@@ -1,0 +1,128 @@
+/**
+ * HMAC-SHA256 signed tokens (Web Crypto — Edge + Node 18+).
+ * Invite tokens: share via link. Session tokens: HttpOnly cookie after unlock.
+ */
+
+const TOKEN_PREFIX = "v1";
+
+function encodeBytes(bytes) {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function decodeBytes(value) {
+  const padded = value.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = padded.length % 4 === 0 ? "" : "=".repeat(4 - (padded.length % 4));
+  const binary = atob(padded + pad);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+function encodeJson(obj) {
+  return encodeBytes(new TextEncoder().encode(JSON.stringify(obj)));
+}
+
+function decodeJson(value) {
+  return JSON.parse(new TextDecoder().decode(decodeBytes(value)));
+}
+
+async function importKey(secret) {
+  if (!secret || secret.length < 32) {
+    throw new Error("ACCESS_TOKEN_SECRET must be at least 32 characters");
+  }
+  return crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"]
+  );
+}
+
+async function signPayload(payload, secret) {
+  const key = await importKey(secret);
+  const body = encodeJson(payload);
+  const sigBytes = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(body));
+  return TOKEN_PREFIX + "." + body + "." + encodeBytes(new Uint8Array(sigBytes));
+}
+
+async function verifyToken(token, secret, expectedType) {
+  if (!token || typeof token !== "string") return { ok: false, reason: "missing" };
+
+  const parts = token.split(".");
+  if (parts.length !== 3 || parts[0] !== TOKEN_PREFIX) return { ok: false, reason: "format" };
+
+  const body = parts[1];
+  const sig = parts[2];
+
+  try {
+    const key = await importKey(secret);
+    const valid = await crypto.subtle.verify(
+      "HMAC",
+      key,
+      decodeBytes(sig),
+      new TextEncoder().encode(body)
+    );
+    if (!valid) return { ok: false, reason: "signature" };
+
+    const payload = decodeJson(body);
+    if (expectedType && payload.typ !== expectedType) return { ok: false, reason: "type" };
+    if (typeof payload.exp !== "number" || payload.exp * 1000 < Date.now()) {
+      return { ok: false, reason: "expired" };
+    }
+
+    return { ok: true, payload };
+  } catch {
+    return { ok: false, reason: "invalid" };
+  }
+}
+
+export async function createInviteToken(secret, options) {
+  const days = options.days || 7;
+  const now = Math.floor(Date.now() / 1000);
+  const payload = {
+    typ: "invite",
+    exp: now + days * 86400,
+    iat: now,
+    jti: crypto.randomUUID(),
+    label: options.label || "share"
+  };
+  const token = await signPayload(payload, secret);
+  return { token, payload };
+}
+
+export async function createSessionToken(secret, invitePayload, sessionHours) {
+  const hours = sessionHours || 24;
+  const now = Math.floor(Date.now() / 1000);
+  const payload = {
+    typ: "session",
+    exp: now + hours * 3600,
+    iat: now,
+    jti: crypto.randomUUID(),
+    via: invitePayload.jti,
+    label: invitePayload.label || "share"
+  };
+  return signPayload(payload, secret);
+}
+
+export async function verifyInviteToken(token, secret) {
+  return verifyToken(token, secret, "invite");
+}
+
+export async function verifySessionToken(token, secret) {
+  return verifyToken(token, secret, "session");
+}
+
+export const SESSION_COOKIE = "fl_session";
+
+export function parseCookie(header, name) {
+  if (!header) return null;
+  const match = header.match(new RegExp("(?:^|;\\s*)" + name + "=([^;]+)"));
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+export function gateEnabled(env) {
+  return String(env.ACCESS_GATE_ENABLED || "").toLowerCase() === "true";
+}

--- a/middleware.js
+++ b/middleware.js
@@ -1,0 +1,40 @@
+import { gateEnabled, parseCookie, verifySessionToken, SESSION_COOKIE } from "./lib/token.mjs";
+
+const PUBLIC_PATHS = new Set(["/unlock.html", "/api/unlock", "/favicon.ico"]);
+
+function isPublicPath(pathname) {
+  if (PUBLIC_PATHS.has(pathname)) return true;
+  if (pathname.startsWith("/.well-known/")) return true;
+  return false;
+}
+
+export default async function middleware(request) {
+  if (!gateEnabled(process.env)) {
+    return;
+  }
+
+  const url = new URL(request.url);
+  if (isPublicPath(url.pathname)) {
+    return;
+  }
+
+  const secret = process.env.ACCESS_TOKEN_SECRET;
+  if (!secret) {
+    return new Response("Access gate misconfigured: missing ACCESS_TOKEN_SECRET", { status: 503 });
+  }
+
+  const session = parseCookie(request.headers.get("cookie"), SESSION_COOKIE);
+  if (session) {
+    const result = await verifySessionToken(session, secret);
+    if (result.ok) {
+      return;
+    }
+  }
+
+  const next = encodeURIComponent(url.pathname + url.search);
+  return Response.redirect(new URL("/unlock.html?next=" + next, request.url), 307);
+}
+
+export const config = {
+  matcher: ["/((?!_next/|_vercel/).*)"]
+};

--- a/scripts/issue-invite.mjs
+++ b/scripts/issue-invite.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+/**
+ * Issue a time-limited invite link for the gated résumé site.
+ *
+ * Usage:
+ *   ACCESS_TOKEN_SECRET=... node scripts/issue-invite.mjs --site https://your-app.vercel.app --days 7 --label "Acme recruiter"
+ *
+ * Never commit ACCESS_TOKEN_SECRET. Use the same value as Vercel env.
+ */
+
+import { createInviteToken } from "../lib/token.mjs";
+
+function readArg(name, fallback) {
+  var idx = process.argv.indexOf(name);
+  if (idx === -1 || !process.argv[idx + 1]) return fallback;
+  return process.argv[idx + 1];
+}
+
+var secret = process.env.ACCESS_TOKEN_SECRET;
+if (!secret || secret.length < 32) {
+  console.error("Set ACCESS_TOKEN_SECRET (min 32 chars) — same value as Vercel.");
+  process.exit(1);
+}
+
+var site = readArg("--site", process.env.SITE_BASE_URL || "https://YOUR-APP.vercel.app");
+var days = Number(readArg("--days", "7"));
+var label = readArg("--label", "share");
+
+if (!Number.isFinite(days) || days < 1 || days > 90) {
+  console.error("--days must be between 1 and 90");
+  process.exit(1);
+}
+
+var result = await createInviteToken(secret, { days: days, label: label });
+var url = site.replace(/\/$/, "") + "/unlock.html?invite=" + encodeURIComponent(result.token);
+
+console.log("");
+console.log("Invite label : " + label);
+console.log("Valid for    : " + days + " day(s)");
+console.log("Expires (UTC): " + new Date(result.payload.exp * 1000).toISOString());
+console.log("");
+console.log("Share link:");
+console.log(url);
+console.log("");
+console.log("Raw token (manual paste on unlock page):");
+console.log(result.token);
+console.log("");

--- a/unlock.html
+++ b/unlock.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>Private access — Facundo Leis Pou</title>
+    <style>
+      :root {
+        --ink: #0f1419;
+        --muted: #5c6b7a;
+        --accent: #1a5f7a;
+        --border: #d8e0e6;
+        --paper: #fff;
+        --bg: #f3f6f8;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: "Segoe UI", system-ui, sans-serif;
+        background: linear-gradient(160deg, #eef3f7, #f8fafb);
+        color: var(--ink);
+        display: grid;
+        place-items: center;
+        padding: 1.5rem;
+      }
+      .card {
+        width: min(420px, 100%);
+        background: var(--paper);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 1.75rem;
+        box-shadow: 0 12px 40px rgba(15, 20, 25, 0.08);
+      }
+      h1 {
+        margin: 0 0 0.35rem;
+        font-size: 1.35rem;
+      }
+      p {
+        margin: 0 0 1rem;
+        color: var(--muted);
+        line-height: 1.5;
+        font-size: 0.95rem;
+      }
+      label {
+        display: block;
+        font-size: 0.8rem;
+        font-weight: 600;
+        margin-bottom: 0.35rem;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      input {
+        width: 100%;
+        font: inherit;
+        padding: 0.65rem 0.75rem;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        margin-bottom: 1rem;
+      }
+      button {
+        width: 100%;
+        font: inherit;
+        font-weight: 600;
+        padding: 0.65rem 1rem;
+        border: none;
+        border-radius: 999px;
+        background: var(--accent);
+        color: #fff;
+        cursor: pointer;
+      }
+      button:disabled {
+        opacity: 0.7;
+        cursor: wait;
+      }
+      .msg {
+        margin-top: 0.85rem;
+        font-size: 0.9rem;
+        min-height: 1.25rem;
+      }
+      .msg.error {
+        color: #b42318;
+      }
+      .msg.ok {
+        color: var(--accent);
+      }
+    </style>
+  </head>
+  <body>
+    <main class="card">
+      <h1>Private résumé</h1>
+      <p>This site is invite-only. Paste your access code or open the link you received.</p>
+      <form id="unlockForm">
+        <label for="token">Access code</label>
+        <input id="token" name="token" autocomplete="off" spellcheck="false" required />
+        <button type="submit" id="submitBtn">Unlock</button>
+      </form>
+      <p class="msg" id="msg" role="status" aria-live="polite"></p>
+    </main>
+    <script>
+      (function () {
+        var params = new URLSearchParams(window.location.search);
+        var next = params.get("next") || "/";
+        var invite = params.get("invite") || "";
+        var form = document.getElementById("unlockForm");
+        var tokenInput = document.getElementById("token");
+        var msg = document.getElementById("msg");
+        var submitBtn = document.getElementById("submitBtn");
+
+        function show(text, type) {
+          msg.textContent = text;
+          msg.className = "msg" + (type ? " " + type : "");
+        }
+
+        function unlock(token) {
+          submitBtn.disabled = true;
+          show("Verifying…", "ok");
+          fetch("/api/unlock", {
+            method: "POST",
+            credentials: "same-origin",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ token: token, next: next })
+          })
+            .then(function (res) {
+              return res.json().then(function (data) {
+                return { status: res.status, data: data };
+              });
+            })
+            .then(function (result) {
+              if (result.data && result.data.ok) {
+                show("Access granted. Redirecting…", "ok");
+                window.location.replace(result.data.redirect || "/");
+                return;
+              }
+              var err = (result.data && result.data.error) || "denied";
+              show(
+                err === "expired"
+                  ? "This access code has expired. Request a new link."
+                  : "Invalid access code. Check the link and try again.",
+                "error"
+              );
+              submitBtn.disabled = false;
+            })
+            .catch(function () {
+              show("Network error. Try again.", "error");
+              submitBtn.disabled = false;
+            });
+        }
+
+        form.addEventListener("submit", function (e) {
+          e.preventDefault();
+          unlock(tokenInput.value.trim());
+        });
+
+        if (invite) {
+          tokenInput.value = invite;
+          unlock(invite);
+        }
+      })();
+    </script>
+  </body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,18 @@
+{
+  "headers": [
+    {
+      "source": "/data/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "private, no-store" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" }
+      ]
+    },
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "X-Frame-Options", "value": "DENY" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
HMAC-signed invite links exchange for HttpOnly session cookies via Edge Middleware; includes unlock page, issue-invite CLI, and access-gate docs. Gate requires Vercel — GitHub Pages alone cannot enforce auth on static JSON.

## Scope
- What changed?
- Why?

## Validation (static site)
- [ ] Served locally (`npx serve .`) — CV and work page load
- [ ] Profile switcher works (`developer`, `sdr`)
- [ ] Language switcher works (`en`, `pt-BR`, `es`)
- [ ] `data/projects.json` valid JSON; demo URLs correct
- [ ] Print / Save as PDF acceptable on developer + en
- [ ] No secrets added or exposed
- [ ] No auth / billing / DNS / GitHub Pages settings change unless intended

## Risk
- Risk level: low / medium / high
- Rollback path: revert merge on `main` (GitHub Pages republishes from previous commit)
